### PR TITLE
Added radio and checkbox UPDATE validators(#189)

### DIFF
--- a/src/app/helper/choice_options_validator.py
+++ b/src/app/helper/choice_options_validator.py
@@ -4,6 +4,11 @@ Choice options validator
 
 
 def check_for_repeated_options(options):
+    """
+    Checks if are repeated options in incoming parameter options
+    :param options:
+    :return:
+    """
     if options is not None:
         if len(options) != len(set(options)):
             return True
@@ -11,6 +16,12 @@ def check_for_repeated_options(options):
 
 
 def check_for_same_options(added, removed):
+    """
+    Checks if are same values in two lists
+    :param added:
+    :param removed:
+    :return:
+    """
     if added and removed:
         return bool(set(added) & set(removed))
     return False

--- a/src/app/helper/choice_options_validator.py
+++ b/src/app/helper/choice_options_validator.py
@@ -25,3 +25,14 @@ def check_for_same_options(added, removed):
     if added and removed:
         return bool(set(added) & set(removed))
     return False
+
+
+def validate_repeats_of_choice_options(added, removed):
+    errors = []
+    if check_for_repeated_options(options=added):
+        errors.append('Repeated added values')
+    if check_for_repeated_options(options=removed):
+        errors.append('Repeated removed values')
+    if check_for_same_options(added=added, removed=removed):
+        errors.append('Identical values in added and removed options')
+    return errors

--- a/src/app/helper/choice_options_validator.py
+++ b/src/app/helper/choice_options_validator.py
@@ -13,3 +13,4 @@ def check_for_repeated_options(options):
 def check_for_same_options(added, removed):
     if added and removed:
         return bool(set(added) & set(removed))
+    return False

--- a/src/app/helper/choice_options_validator.py
+++ b/src/app/helper/choice_options_validator.py
@@ -1,0 +1,15 @@
+"""
+Choice options validator
+"""
+
+
+def check_for_repeated_options(options):
+    if options is not None:
+        if len(options) != len(set(options)):
+            return True
+    return False
+
+
+def check_for_same_options(added, removed):
+    if added and removed:
+        return bool(set(added) & set(removed))

--- a/src/app/helper/choice_options_validator.py
+++ b/src/app/helper/choice_options_validator.py
@@ -28,6 +28,12 @@ def check_for_same_options(added, removed):
 
 
 def validate_repeats_of_choice_options(added, removed):
+    """
+    Validates if same values are repeated in added or removed or are in two lists
+    :param added:
+    :param removed:
+    :return:
+    """
     errors = []
     if check_for_repeated_options(options=added):
         errors.append('Repeated added values')

--- a/src/app/helper/range_validator.py
+++ b/src/app/helper/range_validator.py
@@ -1,0 +1,22 @@
+"""
+Range validator
+"""
+from app.helper.constants import MAX_TEXT_LENGTH
+
+
+def validate_range_text(range_min, range_max):
+    errors = validate_range_checkbox(range_min=range_min, range_max=range_max)
+    if range_min and range_min > MAX_TEXT_LENGTH:
+        errors.append('Min range must\'t be greater than 255')
+    if range_max and range_max > MAX_TEXT_LENGTH:
+        errors.append('Max range must\'t be greater than 255')
+    return errors
+
+
+def validate_range_checkbox(range_min, range_max):
+    errors = []
+    if range_min and range_min < 0:
+        errors.append('Min range must\'t be less than 0')
+    if range_max and range_max < 0:
+        errors.append('Max range must\'t be less than 0')
+    return errors

--- a/src/app/helper/range_validator.py
+++ b/src/app/helper/range_validator.py
@@ -5,6 +5,12 @@ from app.helper.constants import MAX_TEXT_LENGTH
 
 
 def validate_range_text(range_min, range_max):
+    """
+    Validates text range (from 0 to 255)
+    :param range_min:
+    :param range_max:
+    :return:
+    """
     errors = validate_range_checkbox(range_min=range_min, range_max=range_max)
     if range_min and range_min > MAX_TEXT_LENGTH:
         errors.append('Min range must\'t be greater than 255')
@@ -14,6 +20,12 @@ def validate_range_text(range_min, range_max):
 
 
 def validate_range_checkbox(range_min, range_max):
+    """
+    Validates checkbox range (from 0)
+    :param range_min:
+    :param range_max:
+    :return:
+    """
     errors = []
     if range_min and range_min < 0:
         errors.append('Min range must\'t be less than 0')

--- a/src/app/routers/field.py
+++ b/src/app/routers/field.py
@@ -272,7 +272,7 @@ class FieldAPI(Resource):
         field_type = field.field_type
 
         if field_type in (FieldType.Number.value, FieldType.Text.value):
-            is_correct, errors = FieldService.validate_text_or_number_update(data)
+            is_correct, errors = FieldService.validate_text_or_number_update(data=data, field_type=field_type)
             if not is_correct:
                 raise BadRequest(errors)
 
@@ -300,7 +300,7 @@ class FieldAPI(Resource):
             updated_field = BasicField().dump(data)
 
         elif field_type == FieldType.Radio.value:
-            is_correct, errors = FieldService.validate_radio_update(data)
+            is_correct, errors = FieldService.validate_radio_update(data, field_id)
             if not is_correct:
                 raise BadRequest(errors)
 

--- a/src/app/routers/field.py
+++ b/src/app/routers/field.py
@@ -327,7 +327,7 @@ class FieldAPI(Resource):
             )
 
         elif field_type == FieldType.Checkbox.value:
-            is_correct, errors = FieldService.validate_checkbox_update(data)
+            is_correct, errors = FieldService.validate_checkbox_update(data, field_id)
             if not is_correct:
                 raise BadRequest(errors)
 

--- a/src/app/routers/field.py
+++ b/src/app/routers/field.py
@@ -272,7 +272,9 @@ class FieldAPI(Resource):
         field_type = field.field_type
 
         if field_type in (FieldType.Number.value, FieldType.Text.value):
-            is_correct, errors = FieldService.validate_text_or_number_update(data=data, field_type=field_type)
+            is_correct, errors = FieldService.validate_text_or_number_update(
+                data=data,
+                field_type=field_type)
             if not is_correct:
                 raise BadRequest(errors)
 

--- a/src/app/schemas/field.py
+++ b/src/app/schemas/field.py
@@ -195,7 +195,14 @@ class FieldPutSchema(BasicField):
     is_strict = fields.Bool(required=False, data_key="isStrict")
 
     @validates_schema
+    # pylint:disable=no-self-use
     def validate_choice_options_repeats(self, data, **kwargs):
+        """
+        Validates if in added or removed are repeatable values
+        :param data:
+        :param kwargs:
+        :return:
+        """
         added_options = data.get('added_choice_options')
         removed_options = data.get('removed_choice_options')
         if check_for_repeated_options(options=added_options):
@@ -206,7 +213,14 @@ class FieldPutSchema(BasicField):
             raise ValidationError('Identical values in added and removed options')
 
     @validates_schema
+    # pylint:disable=no-self-use
     def validate_new_or_deleted_range(self, data, **kwargs):
+        """
+        Validates if trying to update and delete range in same field
+        :param data:
+        :param kwargs:
+        :return:
+        """
         new_range = data.get('range')
         delete_range = data.get('delete_range')
         if new_range and delete_range:

--- a/src/app/schemas/field.py
+++ b/src/app/schemas/field.py
@@ -210,7 +210,7 @@ class FieldPutSchema(BasicField):
         new_range = data.get('range')
         delete_range = data.get('delete_range')
         if new_range and delete_range:
-            raise ValidationError('Can\'t update and delete фе щту ешьу')
+            raise ValidationError('Can\'t update and delete range')
 
 
 class FieldNumberTextPutSchema(BasicField):

--- a/src/app/schemas/field.py
+++ b/src/app/schemas/field.py
@@ -59,7 +59,9 @@ class FieldPostSchema(BasicField):
         """
         if data.get('field_type') > MAX_FIELD_TYPE or data.get('field_type') < MIN_FIELD_TYPE:
             raise ValidationError(
-                {'fieldType': {'_schema': 'Must be greater than or equal to 1 and less than or equal to 6.'}}
+                {'fieldType': {
+                    '_schema': 'Must be greater than or equal to 1 and less than or equal to 6.'
+                }}
             )
 
     @validates_schema

--- a/src/app/schemas/field.py
+++ b/src/app/schemas/field.py
@@ -195,7 +195,7 @@ class FieldPutSchema(BasicField):
     is_strict = fields.Bool(required=False, data_key="isStrict")
 
     @validates_schema
-    def validate_choice_options(self, data, **kwargs):
+    def validate_choice_options_repeats(self, data, **kwargs):
         added_options = data.get('added_choice_options')
         removed_options = data.get('removed_choice_options')
         if check_for_repeated_options(options=added_options):
@@ -204,6 +204,13 @@ class FieldPutSchema(BasicField):
             raise ValidationError('Repeated removed values')
         if check_for_same_options(added=added_options, removed=removed_options):
             raise ValidationError('Identical values in added and removed options')
+
+    @validates_schema
+    def validate_new_or_deleted_range(self, data, **kwargs):
+        new_range = data.get('range')
+        delete_range = data.get('delete_range')
+        if new_range and delete_range:
+            raise ValidationError('Can\'t update and delete фе щту ешьу')
 
 
 class FieldNumberTextPutSchema(BasicField):

--- a/src/app/schemas/field.py
+++ b/src/app/schemas/field.py
@@ -276,6 +276,7 @@ class FieldCheckboxPutSchema(BasicField):
         required=False,
         data_key="removedChoiceOptions"
     )
+    delete_range = fields.Boolean(data_key='deleteRange')
 
 
 class FieldAutocompletePutSchema(BasicField):

--- a/src/app/schemas/range.py
+++ b/src/app/schemas/range.py
@@ -40,4 +40,4 @@ class RangeSchema(MA.Schema):
         if (min_value and max_value) and min_value > max_value:
             errors.append('min must be less than max')
         if errors:
-            raise ValidationError({'range': {'_schema': errors}})
+            raise ValidationError({'_schema': errors})

--- a/src/app/schemas/range.py
+++ b/src/app/schemas/range.py
@@ -32,9 +32,12 @@ class RangeSchema(MA.Schema):
         :return:
         """
         min_value, max_value = data.get('min'), data.get('max')
+        errors = []
         if min_value and not MIN_POSTGRES_INT < min_value < MAX_POSTGRES_INT:
-            raise ValidationError(f'min must be between {MIN_POSTGRES_INT} and {MAX_POSTGRES_INT}')
+            errors.append(f'min must be between {MIN_POSTGRES_INT} and {MAX_POSTGRES_INT}')
         if max_value and not MIN_POSTGRES_INT < max_value < MAX_POSTGRES_INT:
-            raise ValidationError(f'max must be between {MIN_POSTGRES_INT} and {MAX_POSTGRES_INT}')
+            errors.append(f'max must be between {MIN_POSTGRES_INT} and {MAX_POSTGRES_INT}')
         if (min_value and max_value) and min_value > max_value:
-            raise ValidationError('min must be less than max')
+            errors.append('min must be less than max')
+        if errors:
+            raise ValidationError({'range': {'_schema': errors}})

--- a/src/app/services/field.py
+++ b/src/app/services/field.py
@@ -285,7 +285,7 @@ class FieldService:
             removed=data.get('removedChoiceOptions', [])
         )
         if options_validator:
-            # TODO add custom results to marshmallow result
+            # add custom results to marshmallow result
             errors['choiceOptions'] = {'_schema': options_validator}
         return (not bool(errors), errors)
 
@@ -326,7 +326,7 @@ class FieldService:
             removed=data.get('removedChoiceOptions', [])
         )
         if options_validator:
-            # TODO add custom results to marshmallow result
+            # add custom results to marshmallow result
             errors['choiceOptions'] = {'_schema': options_validator}
 
         options_and_range_validator = FieldService.validate_checkbox_options_and_range_update(

--- a/src/app/services/field.py
+++ b/src/app/services/field.py
@@ -322,7 +322,12 @@ class FieldService:
         return (not bool(errors), errors)
 
     @staticmethod
-    def validate_checkbox_options_and_range_update(field_id, added, removed, new_range, range_deleted):
+    def validate_checkbox_options_and_range_update(
+            field_id,
+            added,
+            removed,
+            new_range,
+            range_deleted):
         """
         Validates choice options depending on existing, new or deleted range
         :param field_id:

--- a/src/app/services/field.py
+++ b/src/app/services/field.py
@@ -298,7 +298,7 @@ class FieldService:
         :param removed:
         :return: list with validation errors
         """
-        additional_options = FieldService._get_choice_additional_options(field_id=field_id)
+        additional_options = FieldService._get_choice_additional_options(field_id)
         current_options = additional_options.get('choiceOptions')
         added_current_options_matches = set(current_options) & set(added)
         removed_current_options_matches = set(current_options) & set(removed)

--- a/src/app/services/field.py
+++ b/src/app/services/field.py
@@ -300,15 +300,15 @@ class FieldService:
         """
         additional_options = FieldService._get_choice_additional_options(field_id)
         current_options = additional_options.get('choiceOptions')
-        added_current_options_matches = set(current_options) & set(added)
-        removed_current_options_matches = set(current_options) & set(removed)
+        added_current_matches = set(current_options) & set(added)
+        removed_current_matches = set(current_options) & set(removed)
         errors = []
-        if added and len(added_current_options_matches) != 0:
+        if added and len(added_current_matches) != 0:
             errors.append('Added choices already exist')
-        if removed and len(removed_current_options_matches) != len(removed):
+        if removed and len(removed_current_matches) != len(removed):
             errors.append('Removed options don\'t exist')
         if removed:
-            if len(set(current_options)) - len(removed_current_options_matches) + len(set(added)) < 1:
+            if len(set(current_options)) - len(removed_current_matches) + len(set(added)) < 1:
                 errors.append('Can\'t delete all options')
         return errors
 

--- a/src/app/services/field.py
+++ b/src/app/services/field.py
@@ -300,13 +300,15 @@ class FieldService:
         """
         additional_options = FieldService._get_choice_additional_options(field_id=field_id)
         current_options = additional_options.get('choiceOptions')
+        added_current_options_matches = set(current_options) & set(added)
+        removed_current_options_matches = set(current_options) & set(removed)
         errors = []
-        if added and len(set(current_options) & set(added)) != 0:
+        if added and len(added_current_options_matches) != 0:
             errors.append('Added choices already exist')
-        if removed and len(set(current_options) & set(removed)) != len(removed):
+        if removed and len(removed_current_options_matches) != len(removed):
             errors.append('Removed options don\'t exist')
         if removed:
-            if len(current_options) - len(removed) + len(added) < 1:
+            if len(set(current_options)) - len(removed_current_options_matches) + len(set(added)) < 1:
                 errors.append('Can\'t delete all options')
         return errors
 

--- a/src/app/services/field.py
+++ b/src/app/services/field.py
@@ -267,10 +267,15 @@ class FieldService:
         """
         Validation for radio field on update
         :param data: received request body
-        :return: errors and whether they occured
+        :return: errors and whether they occurred
         """
         errors = FieldRadioPutSchema().validate(data)
         return (not bool(errors), errors)
+
+    @staticmethod
+    def validate_options(added, removed, range_values):
+        # TODO add validator that validates existance of options
+        pass
 
     @staticmethod
     def validate_checkbox_update(data):
@@ -791,8 +796,8 @@ class FieldService:
     @staticmethod
     @transaction_decorator
     def update_checkbox_field(  # pylint: disable=too-many-arguments
-                                # pylint: disable=too-many-locals
-                                # pylint: disable=too-many-branches
+            # pylint: disable=too-many-locals
+            # pylint: disable=too-many-branches
             field_id,
             name,
             range_max,
@@ -822,7 +827,7 @@ class FieldService:
         if delete_range:
             if field_range is None:
                 raise FieldRangeNotDeleted()
-            deleted_field_range = FieldRangeService.delete(field_id=field.id) # pylint: disable=too-many-branches
+            deleted_field_range = FieldRangeService.delete(field_id=field.id)  # pylint: disable=too-many-branches
             if deleted_field_range is None:
                 raise FieldRangeNotDeleted()
         else:


### PR DESCRIPTION
Added FIELD validators:
- range for text ( 0 to 255) in POST, PUT
- range for checkbox (from 0) in POST, PUT
- if repeats values in choice_options or isEmpty in POST
- if repeats values in added or/and removed lists in PUT
- if send delete_range and update_range in PUT
- if deletes all choices in PUT
- if changes amount of options with outdated range in checkbox in PUT

Changed raise of validation error (returns all problems except for one) 
Example: returns { 'range' : { '_schema' : [ 'error1', 'error2' ] } }